### PR TITLE
ARXINVG-1038 - add support for legacy /abs request parameters

### DIFF
--- a/browse/controllers/abs_page/__init__.py
+++ b/browse/controllers/abs_page/__init__.py
@@ -5,6 +5,7 @@ The primary entrypoint to this module is :func:`.get_abs_page`, which handles
 GET requests to the abs endpoint.
 """
 
+import re
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urljoin
 
@@ -70,6 +71,20 @@ def get_abs_page(arxiv_id: str,
     """
     response_data: Dict[str, Any] = {}
     try:
+
+        if request_params and '/' not in arxiv_id:
+            if 'papernum' in request_params:
+                # To support old references to /abs/<archive>?papernum=\d{7}
+                arxiv_id = f"{arxiv_id}/{request_params['papernum']}"
+            else:
+                for param in request_params:
+                    # singleton case, where the parameter is the value
+                    # To support old references to /abs/<archive>?\d{7}
+                    if not request_params[param] \
+                       and re.match(r'^\d{7}$', param):
+                        arxiv_id = f"{arxiv_id}/{param}"
+                        break
+
         arxiv_identifier = Identifier(arxiv_id=arxiv_id)
         redirect_url = _check_supplied_identifier(arxiv_identifier)
         if redirect_url:

--- a/browse/controllers/abs_page/__init__.py
+++ b/browse/controllers/abs_page/__init__.py
@@ -72,18 +72,7 @@ def get_abs_page(arxiv_id: str,
     response_data: Dict[str, Any] = {}
     try:
 
-        if request_params and '/' not in arxiv_id:
-            if 'papernum' in request_params:
-                # To support old references to /abs/<archive>?papernum=\d{7}
-                arxiv_id = f"{arxiv_id}/{request_params['papernum']}"
-            else:
-                for param in request_params:
-                    # singleton case, where the parameter is the value
-                    # To support old references to /abs/<archive>?\d{7}
-                    if not request_params[param] \
-                       and re.match(r'^\d{7}$', param):
-                        arxiv_id = f"{arxiv_id}/{param}"
-                        break
+        arxiv_id = _check_legacy_id_params(arxiv_id, request_params)
 
         arxiv_identifier = Identifier(arxiv_id=arxiv_id)
         redirect_url = _check_supplied_identifier(arxiv_identifier)
@@ -111,7 +100,7 @@ def get_abs_page(arxiv_id: str,
             download_format_pref,
             add_sciencewise_ping)
 
-        # the following are less critical and the template must display without them
+        # Following are less critical and template must display without them
         try:
             response_data['include_inspire_link'] = include_inspire_link(
                 abs_meta)
@@ -184,6 +173,36 @@ def _check_supplied_identifier(arxiv_identifier: Identifier) -> Optional[str]:
                                     else arxiv_identifier.id)
         return redirect_url
     return None
+
+
+def _check_legacy_id_params(arxiv_id: str, request_params: MultiDict) -> str:
+    """
+    Check for legacy request parameters related to old arXiv identifiers.
+
+    Parameters
+    ----------
+    arxiv_id : str
+
+    request_params: MultiDict
+
+    Returns
+    -------
+    arxiv_id: str
+        A possibly modified version of the input arxiv_id string.
+
+    """
+    if request_params and '/' not in arxiv_id:
+        # To support old references to /abs/<archive>?papernum=\d{7}
+        if 'papernum' in request_params:
+            return f"{arxiv_id}/{request_params['papernum']}"
+        else:
+            for param in request_params:
+                # singleton case, where the parameter is the value
+                # To support old references to /abs/<archive>?\d{7}
+                if not request_params[param] \
+                   and re.match(r'^\d{7}$', param):
+                    return f'{arxiv_id}/{param}'
+    return arxiv_id
 
 
 def _check_context(arxiv_identifier: Identifier,

--- a/browse/domain/metadata.py
+++ b/browse/domain/metadata.py
@@ -103,7 +103,7 @@ class Category:
 
 @dataclass
 class Archive(Category):
-    """Represents an arXiv archive."""
+    """Represents an arXiv archive--the middle level of the taxonomy."""
 
     def __post_init__(self) -> None:
         """Get the full archive name."""
@@ -113,12 +113,12 @@ class Archive(Category):
 
 @dataclass
 class Group(Category):
-    """Represents an arXiv group."""
+    """Represents an arXiv group--the highest (most general) taxonomy level."""
 
     def __post_init__(self) -> None:
         """Get the full group name."""
-        if self.id in taxonomy.ARCHIVES:
-            self.name = taxonomy.ARCHIVES[self.id]['name']
+        if self.id in taxonomy.GROUPS:
+            self.name = taxonomy.GROUPS[self.id]['name']
 
 
 @dataclass(frozen=True)

--- a/browse/domain/metadata.py
+++ b/browse/domain/metadata.py
@@ -125,6 +125,9 @@ class Group(Category):
 class DocMetadata:
     """Class for representing the core arXiv document metadata."""
 
+    raw_safe: str
+    """The raw abs string without submitter email address."""
+
     arxiv_id: str
     """arXiv paper identifier"""
 

--- a/browse/routes/ui.py
+++ b/browse/routes/ui.py
@@ -1,12 +1,11 @@
 """Provides the user intefaces for browse."""
 import re
 from typing import Union
-
-from arxiv import status
 from flask import Blueprint, render_template, request, Response, session, \
     redirect, current_app
 from werkzeug.exceptions import InternalServerError, NotFound
 
+from arxiv import status
 from browse.controllers import abs_page
 from browse.exceptions import AbsNotFound
 from browse.util.clickthrough import is_hash_valid
@@ -32,7 +31,7 @@ def apply_response_headers(response: Response) -> Response:
 
 
 @blueprint.route('/abs', methods=['GET'])
-def bare_abs() -> None:
+def bare_abs() -> Response:
     """Check several legacy request parameters."""
     if request.args:
         if 'id' in request.args:
@@ -48,13 +47,13 @@ def bare_abs() -> None:
                    and re.match(r'^[a-z\-]+(\.[A-Z]{2})?\/\d{7}$', param):
                     return abstract(param)
 
-    """Return 404."""
+    """Return abs-specific 404."""
     raise AbsNotFound
 
 
 @blueprint.route('/abs/', methods=['GET'], defaults={'arxiv_id': ''})
 @blueprint.route('/abs/<path:arxiv_id>', methods=['GET'])
-def abstract(arxiv_id: str) -> Union[str, Response]:
+def abstract(arxiv_id: str) -> Response:
     """Abstract (abs) page view."""
     download_format_pref = request.cookies.get('xxx-ps-defaults')
 
@@ -117,11 +116,12 @@ def clickthrough() -> Response:
 
 @blueprint.route('/list/<context>/<subcontext>')
 def list_articles(current_context: str, yymm: str) -> Response:
-    """List articals by context, month etc.
+    """
+    List articles by context, month etc.
 
     Context might be a context or an archive
     Subcontext should be 'recent' 'new' or a string of format yymm
-"""
+    """
     raise InternalServerError(f'Not yet implemented {current_context} {yymm}')
 
 

--- a/browse/routes/ui.py
+++ b/browse/routes/ui.py
@@ -63,6 +63,12 @@ def abstract(arxiv_id: str) -> Union[str, Response]:
                                                     download_format_pref)
 
     if code == status.HTTP_200_OK:
+        if request.args \
+          and 'fmt' in request.args \
+          and request.args['fmt'] == 'txt':
+            return Response(
+                    response['abs_meta'].raw_safe,
+                    mimetype='text/plain')
         return render_template('abs/abs.html', **response), code, headers
     if code == status.HTTP_301_MOVED_PERMANENTLY:
         return redirect(headers['Location'], code=code)

--- a/browse/routes/ui.py
+++ b/browse/routes/ui.py
@@ -31,6 +31,13 @@ def apply_response_headers(response: Response) -> Response:
 
 @blueprint.route('/abs', methods=['GET'])
 def bare_abs() -> None:
+    if request.args:
+        if 'id' in request.args:
+            return abstract(request.args['id'])
+        elif 'archive' in request.args and 'papernum' in request.args:
+            return abstract(
+                f"{request.args['archive']}/{request.args['papernum']}")
+
     """Return 404."""
     raise NotFound
 

--- a/browse/services/document/metadata.py
+++ b/browse/services/document/metadata.py
@@ -147,8 +147,11 @@ class AbsMetaSession:
             new_month = identifier.month
             new_num = identifier.num + 1
             if (identifier.is_old_id and new_num > 999) \
-               or (not identifier.is_old_id and identifier.year < 2015 and new_num > 9999) \
-               or (not identifier.is_old_id and identifier.year >= 2015 and new_num > 99999):
+               or (not identifier.is_old_id
+                   and identifier.year < 2015
+                   and new_num > 9999) \
+               or (not identifier.is_old_id
+                   and identifier.year >= 2015 and new_num > 99999):
                 new_num = 1
                 new_month = new_month + 1
                 if new_month > 12:
@@ -364,7 +367,7 @@ class AbsMetaSession:
             1. a check for source files with specific, valid file name
                extensions (i.e. for a subset of the allowed source file name
                extensions, the dissemintation formats are predictable)
-            2. if formats cannot be inferred from source file, inspect the
+            2. if formats cannot be inferred from the source file, inspect the
                source type in the document metadata.
 
         Format names are strings. These include 'src', 'pdf', 'ps', 'html',

--- a/browse/services/document/metadata.py
+++ b/browse/services/document/metadata.py
@@ -23,7 +23,7 @@ ARXIV_BUSINESS_TZ = timezone('US/Eastern')
 
 RE_ABS_COMPONENTS = re.compile(r'^\\\\\n', re.MULTILINE)
 RE_FROM_FIELD = re.compile(
-    r'From:\s*(?P<name>[^<]+)?\s*(<(?P<email>.*)>)?')
+    r'(?P<from>From:\s*)(?P<name>[^<]+)?\s+(<(?P<email>.*)>)?')
 RE_DATE_COMPONENTS = re.compile(
     r'^Date\s*(?::|\(revised\s*(?P<version>.*?)\):)\s*(?P<date>.*?)'
     r'(?:\s+\((?P<size_kilobytes>\d+)kb,?(?P<source_type>.*)\))?$')
@@ -457,7 +457,8 @@ class AbsMetaSession:
         # everything else is in the second main component
         prehistory, misc_fields = re.split(r'\n\n', components[1])
 
-        fields: Dict[str, Any] = AbsMetaSession._parse_metadata_fields(key_value_block=misc_fields)
+        fields: Dict[str, Any] = \
+            AbsMetaSession._parse_metadata_fields(key_value_block=misc_fields)
 
         # abstract is the first main component
         fields['abstract'] = components[2]
@@ -484,12 +485,13 @@ class AbsMetaSession:
         if not len(parsed_version_entries) >= 1:
             raise AbsParsingException('At least one version entry expected.')
 
-        (version, version_history, arxiv_id_v) = AbsMetaSession._parse_version_entries(
-            arxiv_id=arxiv_id, version_entry_list=parsed_version_entries
-        )
+        (version, version_history, arxiv_id_v) = \
+            AbsMetaSession._parse_version_entries(
+                arxiv_id=arxiv_id, version_entry_list=parsed_version_entries
+            )
 
         # TODO type ignore: possibly mypy #3937, also see #5389
-        arxiv_identifier=Identifier(arxiv_id=arxiv_id)
+        arxiv_identifier = Identifier(arxiv_id=arxiv_id)
 
         # named (key-value) fields
         if 'categories' not in fields and arxiv_identifier.is_old_id:
@@ -506,8 +508,9 @@ class AbsMetaSession:
         primary_group = Group(id=taxonomy.ARCHIVES[primary_archive.id]['in_group'])  # type: ignore
         doc_license: License = \
             License() if 'license' not in fields else License(recorded_uri=fields['license'])  # type: ignore
-
+        raw_safe = re.sub(RE_FROM_FIELD, r'\g<from>\g<name>', raw, 1)
         return DocMetadata(  # type: ignore
+            raw_safe=raw_safe,
             arxiv_id=arxiv_id,
             arxiv_id_v=arxiv_id_v,
             arxiv_identifier=Identifier(arxiv_id=arxiv_id),

--- a/tests/test_docmetadata.py
+++ b/tests/test_docmetadata.py
@@ -31,8 +31,9 @@ class DocMetadataTest(TestCase):
             run_on_empty_args()
 
         # Do not indent us or we will not run and be tested!:
-        self.assertTrue('missing 12 required positional arguments' in str(ctx.exception))
+        self.assertTrue('missing 13 required positional arguments' in str(ctx.exception))
         #
+        self.assertTrue('raw_safe' in str(ctx.exception))
         self.assertTrue('arxiv_id' in str(ctx.exception))
         self.assertTrue('arxiv_id_v' in str(ctx.exception))
         self.assertTrue('arxiv_identifier' in str(ctx.exception))
@@ -57,10 +58,3 @@ class DocMetadataTest(TestCase):
         self.assertTrue('license' not in str(ctx.exception))
         self.assertTrue('version_history' not in str(ctx.exception))
         self.assertTrue('private' not in str(ctx.exception))
-
-
-
-
-
-
-


### PR DESCRIPTION
This PR essentially covers the conversion of https://github.com/cul-it/arxiv-httpd/blob/master/cgi-bin/abs.pl#L63-L124. 

Some of these cases (like singleton parameters on /abs absent of any other path info) are fairly rare and might be candidates for removal in a future release. 

The `fmt=txt` case is supported by a new `Docmetadata` field called `raw_safe` which is the raw abs string minus the submitter email address.

Examples are demonstrated in test cases.