### PR TITLE
ARXIVNG-1192, ARXIVNG-1202: minor bugfixes

### DIFF
--- a/browse/config.py
+++ b/browse/config.py
@@ -224,3 +224,6 @@ DOCUMENT_CACHE_PATH = os.environ.get(
 
 # Used in linking to /show-email
 SHOW_EMAIL_SECRET = os.environ.get('SHOW_EMAIL_SECRET', 'foo')
+
+# Used in linking to /ct
+CLICKTHROUGH_SECRET = os.environ.get('CLICKTHROUGH_SECRET', 'bar')

--- a/browse/exceptions.py
+++ b/browse/exceptions.py
@@ -4,8 +4,8 @@ from typing import Optional
 
 from arxiv import status
 from arxiv.base.exceptions import handler
-from flask import render_template, make_response, Response
-from werkzeug.exceptions import HTTPException
+from flask import render_template, make_response, Response, jsonify
+from werkzeug.exceptions import HTTPException, BadRequest
 
 
 class AbsNotFound(HTTPException):
@@ -24,8 +24,17 @@ class AbsNotFound(HTTPException):
 
 @handler(AbsNotFound)
 def handle_abs_not_found(error: AbsNotFound) -> Response:
-    """Render the base 404 error page."""
-    rendered = render_template("abs/404.html", **error.data)
+    """Render the base 404 error page for abs."""
+    rendered = render_template('abs/404.html', **error.data)
     response = make_response(rendered)
     response.status_code = status.HTTP_404_NOT_FOUND
+    return response
+
+
+@handler(BadRequest)
+def handle_bad_request(error: BadRequest) -> Response:
+    """Render the 400 error page for browse."""
+    rendered = render_template('400.html', error=error)
+    response = make_response(rendered)
+    response.status_code = status.HTTP_400_BAD_REQUEST
     return response

--- a/browse/factory.py
+++ b/browse/factory.py
@@ -10,7 +10,7 @@ from browse.routes import ui
 from browse.services.database import models
 from browse.services.util.email import generate_show_email_hash
 from browse.filters import doi_urls, arxiv_urlize, arxiv_id_urls, \
-    line_feed_to_br
+    line_feed_to_br, tex_to_utf
 
 
 def create_web_app() -> Flask:
@@ -39,4 +39,5 @@ def create_web_app() -> Flask:
     app.jinja_env.filters['arxiv_id_urls'] = arxiv_id_urls
     app.jinja_env.filters['line_feed_to_br'] = line_feed_to_br
     app.jinja_env.filters['arxiv_urlize'] = arxiv_urlize
+    app.jinja_env.filters['tex_to_utf'] = tex_to_utf
     return app

--- a/browse/factory.py
+++ b/browse/factory.py
@@ -29,7 +29,8 @@ def create_web_app() -> Flask:
     Base(app)
     app.register_blueprint(ui.blueprint)
 
-    ct_url_for = partial(create_ct_url, app.config.get('SECRET_KEY'), url_for)
+    ct_url_for = partial(create_ct_url, app.config.get(
+        'CLICKTHROUGH_SECRET'), url_for)
 
     app.jinja_env.filters['clickthrough_url_for'] = ct_url_for
     app.jinja_env.filters['show_email_hash'] = \

--- a/browse/filters.py
+++ b/browse/filters.py
@@ -8,6 +8,8 @@ from jinja2._compat import text_type
 from jinja2.utils import _digits, _letters, _punctuation_re, _simple_email_re, _word_split_re # type: ignore
 from flask import url_for
 
+from browse.services.util.tex2utf import tex2utf
+
 
 def doi_urls(clickthrough_url_for: Callable[[str], str], text: str) -> str:
     """Creates links to one or more DOIs.
@@ -104,8 +106,8 @@ def arxiv_urlize(
                             middle.endswith('.com')
                     )):
                 # in jinja2 urlize, an additional last argument is trim_url(middle)
-                middle = '<a href="http://%s"%s%s>%s</a>' \
-                         % (middle, rel_attr, target_attr, link_text)
+                middle = '<a href="http://%s"%s%s>%s</a>' % \
+                    (middle, rel_attr, target_attr, link_text)
             if middle.startswith('http://') or \
                     middle.startswith('https://'):
                 # in jinja2 urlize, an additional last argument is trim_url(middle)
@@ -134,9 +136,12 @@ def line_feed_to_br(text: str) -> str:
 
 
 def arxiv_id_urls(text: str) -> str:
-    """Will link either arXiv:<internal_id> or <internal_id> with the full text as the anchor.
+    """
+    Link either arXiv:<internal_id> or <internal_id> with text as anchor.
 
-    The link to just /abs/<internal_id>. However, we do not link viXra:<like_our_internal_id>.
+    The link is simply to /abs/<internal_id>; However, we do not link to
+    viXra:<looks_like_our_internal_id>.
+
     In most cases this should happen after jinja's urlize().
     """
     # Need to escape: if jinja sends us raw txt, needs it,
@@ -151,31 +156,15 @@ def arxiv_id_urls(text: str) -> str:
         url = f'{match.group(1)}<a href="{url_path}">{match.group(2)}</a>'
         return url
 
-    # result = re.sub(r'((ftp|https?)://[^\[\]*{}()\s",>&;]+)',
-    #                 r'<a href="\g<1>">this \g<2> URL</a>',
-    #                 text,
-    #                 re.IGNORECASE)
     # TODO: consider supporting more than just new ID patterns?
     new_id_re = r'([a-z-]+(.[A-Z][A-Z])?\/\d{7}|\d{4}\.\d{4,5})(v\d+)?'
     id_re = re.compile(
         r'(^|[^/A-Za-z-])((arXiv:|(?<!viXra:))(%s))' % new_id_re, re.IGNORECASE)
     result = re.sub(id_re, arxiv_id_link, etxt)
     return Markup(result)
-#
-#     id_re = r'(\W*)(arXiv:|(?<!viXra:))(([a-z-]+(.[A-Z][A-Z])?\/\d{7}|\d{4}\.\d{4,5})(v\d+)?)(.*)'
-#     words = []
-#     vix_spotted=False
-#
-#     split = re.split(r'(\s+|,|vixra:)', text, 0, re.IGNORECASE)
-#     for tkn in split:
-#         mtc = re.match(id_re, tkn)
-#         if mtc and not vix_spotted:
-#             url_path = url_for('browse.abstract', arxiv_id=mtc.group(3))
-#             words.append(f'{mtc.group(1)}<a href="{url_path}">{mtc.group(2)}'\
-#                           '{mtc.group(3)}</a>{mtc.group(7)}')
-#         else:
-#             vix_spotted = re.match('viXra', tkn)
-#             words.append(tkn)
-#
-#     return Markup(u''.join(words))
-#
+
+
+def tex_to_utf(text: str) -> str:
+    """Wraps tex2utf as a filter."""
+
+    return Markup(tex2utf(text))

--- a/browse/routes/ui.py
+++ b/browse/routes/ui.py
@@ -3,7 +3,7 @@ import re
 from typing import Union
 from flask import Blueprint, render_template, request, Response, session, \
     redirect, current_app
-from werkzeug.exceptions import InternalServerError, NotFound
+from werkzeug.exceptions import InternalServerError, BadRequest, NotFound
 from arxiv import status
 from browse.controllers import abs_page
 from browse.exceptions import AbsNotFound
@@ -83,13 +83,15 @@ def trackback(arxiv_id: str) -> Union[str, Response]:
 @blueprint.route('/ct')
 def clickthrough() -> Response:
     """Generate redirect for clickthrough links."""
-    if 'url' in request.args and 'v' in request.args \
-            and is_hash_valid(current_app.config['SECRET_KEY'],
-                              request.args.get('url'),
-                              request.args.get('v')):
-        return redirect(request.args.get('url'))
+    if 'url' in request.args and 'v' in request.args:
+        if is_hash_valid(current_app.config['CLICKTHROUGH_SECRET'],
+                         request.args.get('url'),
+                         request.args.get('v')):
+            return redirect(request.args.get('url'))
+        else:
+            raise BadRequest('Bad click-through redirect')
 
-    raise NotFound()
+    raise NotFound
 
 
 @blueprint.route('/list/<context>/<subcontext>')

--- a/browse/templates/400.html
+++ b/browse/templates/400.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{%- block title -%}{{ error.description }}{%- endblock -%}
+
+{% block head %}
+  {{ super() }}
+{% endblock head %}
+
+{% block content %}
+
+<h1>{{ error.description }}</h1>
+<p>An error has occured. If this problem persists, please contact
+  <a href="mailto:help@arxiv.org">help@arxiv.org</a> explaining the
+  circumstances of this error and quoting both the URL of this page in the
+  referring page.</p>
+
+<hr>
+<p><i>The following provides general information and links for use in the
+event of accident, error or problem with the e-print archives.</i></p>
+<p>Problems and errors can be reported to
+  <a href="mailto:help@arxiv.org">help@arxiv.org</a>. If you do send us email,
+  please provide:</p>
+<ol>
+  <li>The archive (e.g. astro-ph) and/or article identifier
+    (e.g. 0704.4125 or hep-th/9502213) causing the problem.</li>
+  <li>The URL which causes the problem</li>
+  <li>A brief description of what you expected to see/happen and what you
+    observed.
+  </li>
+</ol>
+<p>Thanks in advance for error reports; and apologies for any
+  inconvenience that the malfunctioning of arXiv.org may cause.</p>
+
+{%- endblock -%}

--- a/browse/templates/abs/abs.html
+++ b/browse/templates/abs/abs.html
@@ -45,8 +45,7 @@
     <div class="subheader">
       <h1>{% if abs_meta.primary_archive.id != abs_meta.primary_category.id %}{{ abs_meta.primary_archive.name }} > {% endif %}{{ abs_meta.primary_category.name }}</h1>
     </div>
-    <h1 class="title mathjax"><span class="descriptor">Title:</span>{{ abs_meta.title|arxiv_id_urls }}</h1>
-    {# TODO: authors section #}
+    <h1 class="title mathjax"><span class="descriptor">Title:</span>{{ abs_meta.title|tex_to_utf|arxiv_id_urls }}</h1>
     <div class="authors"><span class="descriptor">Authors:</span>
       {%- include "/abs/author_links.html" %}
     </div>
@@ -131,7 +130,7 @@
 {%- endmacro -%}
 
 {%- macro generate_dateline() -%}
-  (Submitted on {{ abs_meta.version_history[0].submitted_date.strftime('%-d %b %Y') }} 
+  (Submitted on {{ abs_meta.version_history[0].submitted_date.strftime('%-d %b %Y') }}
   {%- if abs_meta.version != 1 %}(<a href="{{ url_for('.abstract', arxiv_id='{}v1'.format(abs_meta.arxiv_id)) }}">v1</a>){%- endif %}
   {%- if abs_meta.version > 1 and abs_meta.version < abs_meta.version_history[-1].version -%}
   , revised {{ abs_meta.version_history[abs_meta.version-1].submitted_date.strftime('%-d %b %Y') }} (this version, v{{ abs_meta.version }})

--- a/tests/data/abs_files/ftp/acc-phys/papers/9411/9411001.abs
+++ b/tests/data/abs_files/ftp/acc-phys/papers/9411/9411001.abs
@@ -4,7 +4,7 @@ arXiv:acc-phys/9411001
 From: Salman Habib <NdENv@u0-4VU8.fWz4.XrM>
 Date: Tue, 1 Nov 1994 18:57:48 GMT   (199kb)
 
-Title: Symplectic Computation of Lyapunov Exponents
+Title: {\gamma}-Cascade Symplectic Computation of Lyapunov arXiv:1701.00001
 Authors: Salman Habib and Robert D. Ryne
 Categories: acc-phys physics.acc-ph
 Comments: 12 pages, uuencoded PostScript (figures included)


### PR DESCRIPTION
* ARXIVNG-1192 - adds a filter that wraps the tex2utf function. Filter is being applied to the title field
* ARXIVNG-1202 - adds a generic 400 template so that the /ct route can raise `BadRequest` with a message when the hash doesn't match