### PR TITLE
Fixes browse context for canonical archives

### DIFF
--- a/browse/controllers/abs_page/__init__.py
+++ b/browse/controllers/abs_page/__init__.py
@@ -279,8 +279,8 @@ def _check_legacy_id_params(arxiv_id: str) -> str:
 
 
 def _check_context(arxiv_identifier: Identifier,
-                   primary_category: Category,
-                   response_data) -> None:
+                   primary_category: Optional[Category],
+                   response_data: Dict[str,Any]) -> None:
     """
     Check context in request parameters and update response accordingly.
 
@@ -302,15 +302,17 @@ def _check_context(arxiv_identifier: Identifier,
             or context in taxonomy.CATEGORIES
             or context in taxonomy.ARCHIVES)):
         context = request.args['context']
-    else:
+    elif primary_category:
         pc = primary_category.canonical or primary_category
-        if not arxiv_identifier.is_old_id:
+        if not arxiv_identifier.is_old_id: # new style IDs
             context = pc.id
         else:  # Old style id
             if pc.id in taxonomy.ARCHIVES:
                 context = pc.id
             else:
                 context = arxiv_identifier.archive
+    else:
+        context = None
 
     response_data['browse_context'] = context
 
@@ -344,13 +346,6 @@ def _check_context(arxiv_identifier: Identifier,
         if context:
             next_url = next_url + '&context='+context
             prev_url = prev_url + '&context='+context
-
-
-    print('next_url is ')
-    print( next_url )
-
-    print('prev_url is ')
-    print( prev_url )
 
     response_data['browse_context_previous_url'] = prev_url
     response_data['browse_context_next_url'] = next_url

--- a/browse/controllers/abs_page/__init__.py
+++ b/browse/controllers/abs_page/__init__.py
@@ -20,6 +20,7 @@ from werkzeug.exceptions import InternalServerError
 from arxiv import status, taxonomy
 from arxiv.base import logging
 from browse.domain.metadata import DocMetadata
+from browse.domain.category import Category
 from browse.exceptions import AbsNotFound
 from browse.services.search.search_authors import queries_for_authors, \
     split_long_author_list
@@ -188,6 +189,7 @@ def _non_critical_abs_data(abs_meta:DocMetadata, arxiv_identifier:Identifier, re
 
     # Browse context
     _check_context(arxiv_identifier,
+                   abs_meta.primary_category,
                    response_data)
 
 
@@ -277,40 +279,81 @@ def _check_legacy_id_params(arxiv_id: str) -> str:
 
 
 def _check_context(arxiv_identifier: Identifier,
-                   response_data: Dict[str, Any]) -> None:
+                   primary_category: Category,
+                   response_data) -> None:
     """
     Check context in request parameters and update response accordingly.
 
     Parameters
     ----------
     arxiv_identifier : :class:`Identifier`
-
-    response_data: dict
+    primary_category : :class: `Category`
 
     Returns
     -------
-    None
+    Dict of values to add to response_data
 
     """
+    
+    # Setup the context
     context = None
-    if 'context' not in request.args:
-        if arxiv_identifier.is_old_id:
-            # This is just because legacy uses the archive as the browse
-            # context for old IDs.
-            response_data['browse_context'] \
-                = arxiv_identifier.archive
-    else:
+    if ('context' in request.args and (
+            context == 'arxiv'
+            or context in taxonomy.CATEGORIES
+            or context in taxonomy.ARCHIVES)):
         context = request.args['context']
+    else:
+        pc = primary_category.canonical or primary_category
+        if not arxiv_identifier.is_old_id:
+            context = pc.id
+        else:  # Old style id
+            if pc.id in taxonomy.ARCHIVES:
+                context = pc.id
+            else:
+                context = arxiv_identifier.archive
 
-    if (context in taxonomy.CATEGORIES
-            or context in taxonomy.ARCHIVES or context == 'arxiv'):
-        response_data['browse_context'] = context
+    response_data['browse_context'] = context
 
+    # Setup prev/next URLs
     if arxiv_identifier.is_old_id or context == 'arxiv':
-        response_data['browse_context_next_id'] = \
-            metadata.get_next_id(arxiv_identifier)
-        response_data['browse_context_previous_id'] = \
-            metadata.get_previous_id(arxiv_identifier)
+        next_id = metadata.get_next_id(arxiv_identifier)
+        #TODO might have to pass non-arxiv context to url_for becuase
+        #of examples like physics/9707012
+        if next_id:
+            next_url = url_for('browse.abstract',
+                               arxiv_id=next_id.id,
+                               context='arxiv' if context == 'arxiv' else None)
+        else:
+            next_url = None
+
+        previous_id = metadata.get_previous_id(arxiv_identifier)
+        if previous_id:
+            prev_url = url_for('browse.abstract',
+                               arxiv_id=previous_id.id,
+                               context='arxiv' if context == 'arxiv' else None)
+        else:
+            prev_url = None
+            
+    else:
+        # This is the case where not in arXiv or a archive,
+        # so just let the prevnext controller figure it out.
+        
+        #TODO do url_for() here
+        next_url = 'https://arxiv.org/prevnext?site=arxiv.org&id='+arxiv_identifier.id+'&function=next'
+        prev_url = 'https://arxiv.org/prevnext?site=arxiv.org&id='+arxiv_identifier.id+'&function=prev'
+        if context:
+            next_url = next_url + '&context='+context
+            prev_url = prev_url + '&context='+context
+
+
+    print('next_url is ')
+    print( next_url )
+
+    print('prev_url is ')
+    print( prev_url )
+
+    response_data['browse_context_previous_url'] = prev_url
+    response_data['browse_context_next_url'] = next_url
 
 
 def _check_sciencewise_ping(paper_id_v: str) -> bool:

--- a/browse/domain/category.py
+++ b/browse/domain/category.py
@@ -30,6 +30,7 @@ class Category:
     name: str = field(init=False, compare=False)
     """The name of the category (e.g. Digital Libraries)."""
 
+    #TODO should probably be changed to get_canonical to avoid confusion
     canonical: Union['Category', None] = field(init=False, compare=False)
 
     def __hash__(self)->int:

--- a/browse/domain/identifier.py
+++ b/browse/domain/identifier.py
@@ -207,7 +207,10 @@ class Identifier:
         by design: https://stackoverflow.com/a/37557540/3096687
 
         """
-        return self.__dict__ == other.__dict__
+        try:
+            return self.__dict__ == other.__dict__
+        except AttributeError:
+            return False
 
 
 def canonical_url(id: str, version: int = 0)->str:

--- a/browse/templates/abs/extra_services.html
+++ b/browse/templates/abs/extra_services.html
@@ -52,51 +52,40 @@
 {%- endmacro -%}
 
 {%- macro generate_browse_context() -%}
-  {%- set current_context = browse_context if browse_context else abs_meta.primary_category.id -%}
   <h3>Current browse context:</h3>
-  <div class="current">{{ current_context }}</div>
-  <div class="prevnext">
-    {% if abs_meta.arxiv_identifier.is_old_id or current_context == 'arxiv' -%}
-      {% if browse_context_previous_id -%}
-        <span class="arrow">
-        <a href="{{ url_for('browse.abstract', arxiv_id=browse_context_previous_id.id, context='arxiv' if current_context == 'arxiv' else None) }}"
-           accesskey="p" title="previous in {{ current_context }} (accesskey p)">&lt;&nbsp;prev</a>
-        </span>
-         {%- else -%}
-        <span class="nolink">&lt;&nbsp;previous</span>
-      {% endif -%}
-    {% else -%}
-      {%- set prevnext_url = 'https://arxiv.org/prevnext?site=arxiv.org&id='+abs_meta.arxiv_identifier.id+'&context='+current_context -%}
-        <span class="arrow">
-          <a href="{{ prevnext_url }}&amp;function=prev"
-             accesskey="p" title="previous in {{ current_context }} (accesskey p)">&lt;&nbsp;prev</a>
-        </span>
-    {%- endif -%}
-    &nbsp;|&nbsp;
-    {%- if abs_meta.arxiv_identifier.is_old_id or current_context == 'arxiv' -%}
-        {% if browse_context_next_id %}
-          <span class="arrow">
-          <a href="{{ url_for('browse.abstract', arxiv_id=browse_context_next_id.id, context='arxiv' if current_context == 'arxiv' else None) }}"
-             accesskey="n" title="next in {{ current_context }} (accesskey n)">next&nbsp;&gt;</a>
-          </span>
-        {%- else -%}
-          <span class="nolink">next&nbsp;&gt;</span>
-        {%- endif -%}
-    {%- else -%}
-          <span class="arrow">
-          <a href="{{ prevnext_url }}&amp;function=next"
-             accesskey="n" title="next in {{ current_context }} (accesskey n)">next&nbsp;&gt;</a>
-          </span>
-    {%- endif -%}
-    <br/>
-  </div>
+  <div class="current">{{ browse_context }}</div>
 
-  {%- if current_context != 'arxiv' -%}
+  <div class="prevnext">
+    
+  {% if browse_context_previous_url -%}
+  <span class="arrow">
+    <a href="{{browse_context_previous_url }}"
+       accesskey="p" title="previous in {{ browse_context }} (accesskey p)">&lt;&nbsp;prev</a>
+  </span>
+  {%- else -%}
+  <span class="nolink">&lt;&nbsp;previous</span>
+  {% endif -%}        
+
+  &nbsp;|&nbsp;
+  
+  {% if browse_context_next_url %}
+  <span class="arrow">
+    <a href="{{browse_context_next_url}}" accesskey="n"
+       title="next in {{ browse_context }} (accesskey n)">next&nbsp;&gt;</a>
+  </span>
+  {%- else -%}
+  <span class="nolink">next&nbsp;&gt;</span>
+  {%- endif -%}
+
+  <br/>
+  </div>{#end div.prevnext#}
+
+  {%- if browse_context != 'arxiv' -%}
   {#- This fixes a bug in the classic UI logic -#}
-<div class="list">
-  <a href="{{url_for('.list_articles',context=current_context, subcontext='new')}}">new</a>&nbsp;|
-  <a href="{{url_for('.list_articles',context=current_context, subcontext='recent')}}">recent</a>&nbsp;|
-  <a href="{{url_for('.list_articles',context=current_context, subcontext=abs_meta.arxiv_identifier.yymm)}}">
+  <div class="list">
+    <a href="{{url_for('.list_articles',context=browse_context, subcontext='new')}}">new</a>&nbsp;|
+    <a href="{{url_for('.list_articles',context=browse_context, subcontext='recent')}}">recent</a>&nbsp;|
+    <a href="{{url_for('.list_articles',context=browse_context, subcontext=abs_meta.arxiv_identifier.yymm)}}">
       {{- abs_meta.arxiv_identifier.yymm -}}</a>
   </div>
   {%- endif -%}
@@ -104,7 +93,7 @@
   {%- if not abs_meta.arxiv_identifier.is_old_id and (abs_meta.get_browse_context_list()|length > 1) -%}
   <h3>Change to browse by:</h3>
   <div class="switch">
-    {% for category in abs_meta.get_browse_context_list() if not (current_context==category) %}
+    {% for category in abs_meta.get_browse_context_list() if not (browse_context==category) %}
       {%- set switch_url = url_for('browse.abstract', arxiv_id=abs_meta.arxiv_identifier.id, context=category) -%}
       {% if '.' in category %}
       <span class="subclass"><a href="{{ switch_url}}">{{ category }}</a></span>
@@ -116,6 +105,7 @@
   </div>
   {% endif %}
 {%- endmacro -%}
+
 
 {%- macro generate_dblp_section(author_cutoff=5) -%}
   <div class="dblp">

--- a/tests/test_browse_links.py
+++ b/tests/test_browse_links.py
@@ -1,0 +1,103 @@
+import unittest
+
+from urllib.parse import urlparse, parse_qs, unquote
+
+from bs4 import BeautifulSoup
+
+from tests.test_abs_parser import ABS_FILES
+from browse.services.document.metadata import AbsMetaSession
+from browse.domain.license import ASSUMED_LICENSE_URI
+
+import os
+
+from app import app
+
+
+class BrowseLinksTest(unittest.TestCase):
+
+    def setUp(self):
+        app.testing = True
+        app.config['APPLICATION_ROOT'] = ''
+        self.app = app.test_client()
+
+    def test_newer_id(self):
+        rv = self.app.get('/abs/1604.08245')
+        self.assertEqual(rv.status_code, 200)
+        html = BeautifulSoup(rv.data.decode('utf-8'), 'html.parser')
+        self.assertIsNotNone(html)
+
+        current_context = html.find('div', 'current')
+        self.assertIsNotNone(current_context)
+        self.assertEqual(current_context.text, 'cs.MM')
+
+        pn_div = html.find('div', 'prevnext')
+        self.assertIsNotNone(pn_div, 'Should have div.prevnext')
+        self.assertEqual(pn_div.find_all('span')[0].a['title'],
+                         'previous in cs.MM (accesskey p)',
+                         'Should have previous span.arrow subtags with correct category')
+
+        self.assertEqual(pn_div.find_all('span')[1].a['title'],
+                         'next in cs.MM (accesskey n)',
+                         'Should have next span.arrow subtags with correct category')
+
+        switches = html.find_all('div', 'switch')
+        self.assertEqual(len(switches),  1,
+                         'Should only be one context to switch to')
+        self.assertEqual(switches[0].a.text, 'cs',
+                         'switch context should be cs')
+
+    def test_older_id(self):
+        rv = self.app.get('/abs/ao-sci/9503001')
+        self.assertEqual(rv.status_code, 200)
+        html = BeautifulSoup(rv.data.decode('utf-8'), 'html.parser')
+        self.assertIsNotNone(html)
+
+        current_context = html.find('div', 'current')
+        self.assertIsNotNone(current_context)
+        self.assertEqual(current_context.text, 'ao-sci')
+
+        pn_div = html.find('div', 'prevnext')
+        self.assertIsNotNone(pn_div, 'Should have div.prevnext')
+
+        atags = pn_div.find_all('a')
+        self.assertTrue(len(atags) >= 1,
+                        'Shold be at least one <a> tags for prev/next')
+
+        self.assertEqual(pn_div.find_all('a')[0]['title'],
+                         'previous in ao-sci (accesskey p)',
+                         'Should have previous span.arrow subtags with correct category')
+
+        switches = html.find_all('div', 'switch')
+        self.assertEqual(len(switches),  0,
+                         'Should be no other contxt to switch to')
+
+    def test_older_id_w_canonical(self):
+        rv = self.app.get('/abs/physics/9707012')
+        self.assertEqual(rv.status_code, 200)
+        html = BeautifulSoup(rv.data.decode('utf-8'), 'html.parser')
+        self.assertIsNotNone(html)
+
+        current_context = html.find('div', 'current')
+        self.assertIsNotNone(current_context)
+        self.assertEqual(current_context.text, 'math-ph')
+
+        pn_div = html.find('div', 'prevnext')
+        self.assertIsNotNone(pn_div, 'Should have div.prevnext')
+
+        atags = pn_div.find_all('a')
+        self.assertTrue(len(atags) >= 1, 'Shold be at least one <a> tags for prev/next')
+        
+        self.assertEqual(pn_div.find_all('a')[0]['title'],
+                         'previous in physics (accesskey p)',
+                         'Should have previous span.arrow subtags with correct category')
+
+        switches = html.find_all('div', 'switch')
+        self.assertEqual(len(switches),  0,
+                         'Should be no other contxt to switch to')
+
+        other_atags = html.find('div','list').find_all('a')
+        self.assertTrue(other_atags)
+        self.assertTrue( len(other_atags) >= 3, "should be at least 3 a tags in list")
+        self.assertEqual( other_atags[0].href , '/list/physics/new')
+        self.assertEqual( other_atags[1].href , '/list/physics/recent')
+        self.assertEqual( other_atags[2].href , '/list/physics/9707')

--- a/tests/test_browse_links.py
+++ b/tests/test_browse_links.py
@@ -88,7 +88,7 @@ class BrowseLinksTest(unittest.TestCase):
         self.assertTrue(len(atags) >= 1, 'Shold be at least one <a> tags for prev/next')
         
         self.assertEqual(pn_div.find_all('a')[0]['title'],
-                         'previous in physics (accesskey p)',
+                         'previous in math-ph (accesskey p)',
                          'Should have previous span.arrow subtags with correct category')
 
         switches = html.find_all('div', 'switch')
@@ -97,7 +97,7 @@ class BrowseLinksTest(unittest.TestCase):
 
         other_atags = html.find('div','list').find_all('a')
         self.assertTrue(other_atags)
-        self.assertTrue( len(other_atags) >= 3, "should be at least 3 a tags in list")
-        self.assertEqual( other_atags[0].href , '/list/physics/new')
-        self.assertEqual( other_atags[1].href , '/list/physics/recent')
-        self.assertEqual( other_atags[2].href , '/list/physics/9707')
+        self.assertTrue(len(other_atags) >= 3, "should be at least 3 a tags in list")
+        self.assertEqual(other_atags[0]['href'], '/list/math-ph/new')
+        self.assertEqual(other_atags[1]['href'], '/list/math-ph/recent')
+        self.assertEqual(other_atags[2]['href'], '/list/math-ph/9707')


### PR DESCRIPTION

Issue: Browse context is not always showing the canonical archive when viewing an old ID
https://culibrary.atlassian.net/browse/ARXIVNG-1262
"e.g. for physics/9707012 the archive in the browse context is "physics" per the identifier. It should be "math-ph" because the primary category is "math-ph" which is in the archive of the same name."

Added tests for new ID, old ID and old ID with canonicalized primary.
Refactored browse template macro to move most of the logic out of the template and into the controller.