### PR TITLE
ARXIVNG-1275 - Handle database errors more gracefully

### DIFF
--- a/browse/config.py
+++ b/browse/config.py
@@ -211,6 +211,9 @@ SQLALCHEMY_ECHO = False
 SQLALCHEMY_RECORD_QUERIES = False
 
 # Disable DB queries even if other SQLAlchemy config are defined
+# This, for example, could be used in conjunction with the `no-write` runlevel
+# in the legacy infrastructure, which is a case where we know the DB is
+# unavailable and thus intentionally bypass any DB access.
 BROWSE_DISABLE_DATABASE = os.environ.get('BROWSE_DISABLE_DATABASE', False)
 
 # Paths to .abs and source files

--- a/browse/config.py
+++ b/browse/config.py
@@ -210,6 +210,9 @@ SQLALCHEMY_TRACK_MODIFICATIONS = False
 SQLALCHEMY_ECHO = False
 SQLALCHEMY_RECORD_QUERIES = False
 
+# Disable DB queries even if other SQLAlchemy config are defined
+BROWSE_DISABLE_DATABASE = os.environ.get('BROWSE_DISABLE_DATABASE', False)
+
 # Paths to .abs and source files
 DOCUMENT_LATEST_VERSIONS_PATH = os.environ.get(
     'DOCUMENT_LATEST_VERSIONS_PATH', 'tests/data/abs_files/ftp')

--- a/browse/controllers/abs_page/__init__.py
+++ b/browse/controllers/abs_page/__init__.py
@@ -179,14 +179,17 @@ def _non_critical_abs_data(abs_meta: DocMetadata,
                            arxiv_identifier: Identifier,
                            response_data: Dict)->None:
     """Get additional non-essential data for the abs page."""
-    response_data['include_inspire_link'] = include_inspire_link(
-        abs_meta)
+    # The DBLP listing and trackback counts depend on the DB.
     response_data['dblp'] = _check_dblp(abs_meta)
     response_data['trackback_ping_count'] = count_trackback_pings(
         arxiv_identifier.id)
     if response_data['trackback_ping_count'] > 0:
         response_data['trackback_ping_latest'] = \
             get_trackback_ping_latest_date(arxiv_identifier.id)
+
+    # Include INSPIRE link in references & citations section
+    response_data['include_inspire_link'] = include_inspire_link(
+        abs_meta)
 
     # Ancillary files
     response_data['ancillary_files'] = \
@@ -204,6 +207,7 @@ def _check_request_headers(docmeta: DocMetadata,
     """Check the request headers, update the response headers accordingly."""
     last_mod_dt: datetime = docmeta.modified
 
+    # Latest trackback ping time depends on the database
     if 'trackback_ping_latest' in response_data \
        and isinstance(response_data['trackback_ping_latest'], datetime) \
        and response_data['trackback_ping_latest'] > last_mod_dt:

--- a/browse/controllers/abs_page/__init__.py
+++ b/browse/controllers/abs_page/__init__.py
@@ -364,7 +364,7 @@ def _check_context(arxiv_identifier: Identifier,
 def _check_sciencewise_ping(paper_id_v: str) -> bool:
     """Check whether paper has a ScienceWISE ping."""
     try:
-        return has_sciencewise_ping(paper_id_v)
+        return has_sciencewise_ping(paper_id_v)  # type: ignore
     except IOError:
         return False
 

--- a/browse/services/database/__init__.py
+++ b/browse/services/database/__init__.py
@@ -128,7 +128,6 @@ def count_trackback_pings(paper_id: str) -> int:
         return count
     except NoResultFound:
         return 0
-    return 0
 
 
 @db_handle_operational_error(logger=logger, default_return_val=0)

--- a/browse/services/database/__init__.py
+++ b/browse/services/database/__init__.py
@@ -3,7 +3,7 @@
 import ipaddress
 from datetime import datetime
 from dateutil.tz import tzutc, gettz
-from typing import List, Optional, Any
+from typing import List, Optional, Any, Callable
 from sqlalchemy.sql import func
 from sqlalchemy.orm import Query
 from sqlalchemy.orm.exc import NoResultFound
@@ -19,10 +19,12 @@ from logging import Logger
 logger = logging.getLogger(__name__)
 app_config = get_application_config()
 
-def db_handle_operational_error(logger: Logger, default_return_val: Any):
-    """Decorator for handling operational database errors."""
-    def decorator(func):
-        def wrapper(*args, **kwargs):
+
+def db_handle_operational_error(logger: Logger, default_return_val: Any) \
+        -> Any:
+    """Handle operational database errors via decorator."""
+    def decorator(func: Callable) -> Any:
+        def wrapper(*args, **kwargs):  # type: ignore
             # Bypass attempt to perform query and just return default value
             is_db_disabled: bool = app_config.get(
                 'BROWSE_DISABLE_DATABASE') or False

--- a/browse/services/database/__init__.py
+++ b/browse/services/database/__init__.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 app_config = get_application_config()
 
 
-def db_handle_operational_error(logger: Logger, default_return_val: Any) \
+def db_handle_error(logger: Logger, default_return_val: Any) \
         -> Any:
     """Handle operational database errors via decorator."""
     def decorator(func: Callable) -> Any:
@@ -35,6 +35,8 @@ def db_handle_operational_error(logger: Logger, default_return_val: Any) \
                 return default_return_val
             try:
                 return func(*args, **kwargs)
+            except NoResultFound:
+                return default_return_val
             except (OperationalError, DBAPIError) as ex:
                 if logger:
                     logger.warning(
@@ -60,121 +62,93 @@ def __paper_trackbacks_query(paper_id: str) -> Query:
         .filter(TrackbackPing.status == 'accepted')
 
 
-@db_handle_operational_error(logger=logger, default_return_val=None)
+@db_handle_error(logger=logger, default_return_val=None)
 def get_institution(ip: str) -> Optional[str]:
     """Get institution label from IP address."""
     decimal_ip = int(ipaddress.ip_address(ip))
-    try:
-        stmt = (
-            db.session.query(
-                MemberInstitution.label,
-                func.sum(MemberInstitutionIP.exclude).label("exclusions")
-            ).
-            join(MemberInstitutionIP).
-            filter(
-                MemberInstitutionIP.start <= decimal_ip,
-                MemberInstitutionIP.end >= decimal_ip
-            ).
-            group_by(MemberInstitution.label).
-            subquery()
-        )
-        institution_name = db.session.query(stmt.c.label).\
-            filter(stmt.c.exclusions == 0).one().label
-        assert isinstance(institution_name, str)
-        return institution_name
-    except NoResultFound:
-        return None
+
+    stmt = (
+        db.session.query(
+            MemberInstitution.label,
+            func.sum(MemberInstitutionIP.exclude).label("exclusions")
+        ).
+        join(MemberInstitutionIP).
+        filter(
+            MemberInstitutionIP.start <= decimal_ip,
+            MemberInstitutionIP.end >= decimal_ip
+        ).
+        group_by(MemberInstitution.label).
+        subquery()
+    )
+    institution_name = db.session.query(stmt.c.label).\
+        filter(stmt.c.exclusions == 0).one().label
+    assert isinstance(institution_name, str)
+    return institution_name
 
 
-@db_handle_operational_error(logger=logger, default_return_val=[])
+@db_handle_error(logger=logger, default_return_val=[])
 def get_all_trackback_pings() -> List[TrackbackPing]:
     """Get all trackback pings in database."""
-    try:
-        return list(__all_trackbacks_query().all())
-    except NoResultFound:
-        return []
+    return list(__all_trackbacks_query().all())
 
 
-@db_handle_operational_error(logger=logger, default_return_val=[])
+@db_handle_error(logger=logger, default_return_val=[])
 def get_trackback_pings(paper_id: str) -> List[TrackbackPing]:
     """Get trackback pings for a particular document (paper_id)."""
-    try:
-        return list(__paper_trackbacks_query(paper_id).all())
-    except NoResultFound:
-        return []
-    return []
+    return list(__paper_trackbacks_query(paper_id).all())
 
 
-@db_handle_operational_error(logger=logger, default_return_val=None)
+@db_handle_error(logger=logger, default_return_val=None)
 def get_trackback_ping_latest_date(paper_id: str) -> Optional[datetime]:
     """Get the most recent accepted trackback datetime for a paper_id."""
-    try:
-        timestamp: int = db.session.query(
-            func.max(TrackbackPing.approved_time)
-        ).filter(TrackbackPing.document_id == Document.document_id) \
-            .filter(Document.paper_id == paper_id) \
-            .filter(TrackbackPing.status == 'accepted').scalar()
-        dt = datetime.fromtimestamp(timestamp, tz=gettz('US/Eastern'))
-        dt = dt.astimezone(tz=tzutc())
-        return dt
-    except NoResultFound:
-        return None
+    timestamp: int = db.session.query(
+        func.max(TrackbackPing.approved_time)
+    ).filter(TrackbackPing.document_id == Document.document_id) \
+        .filter(Document.paper_id == paper_id) \
+        .filter(TrackbackPing.status == 'accepted').scalar()
+    dt = datetime.fromtimestamp(timestamp, tz=gettz('US/Eastern'))
+    dt = dt.astimezone(tz=tzutc())
+    return dt
 
 
-@db_handle_operational_error(logger=logger, default_return_val=0)
+@db_handle_error(logger=logger, default_return_val=0)
 def count_trackback_pings(paper_id: str) -> int:
     """Count trackback pings for a particular document (paper_id)."""
-    try:
-        count: int = __paper_trackbacks_query(paper_id) \
-            .group_by(TrackbackPing.url).count()
-        return count
-    except NoResultFound:
-        return 0
+    count: int = __paper_trackbacks_query(paper_id) \
+        .group_by(TrackbackPing.url).count()
+    return count
 
 
-@db_handle_operational_error(logger=logger, default_return_val=0)
+@db_handle_error(logger=logger, default_return_val=0)
 def count_all_trackback_pings() -> int:
     """Count trackback pings for all documents, without DISTINCT(URL)."""
-    try:
-        c = __all_trackbacks_query().count()
-        assert isinstance(c, int)
-        return c
-    except NoResultFound:
-        return 0
+    c = __all_trackbacks_query().count()
+    assert isinstance(c, int)
+    return c
 
 
-@db_handle_operational_error(logger=logger, default_return_val=False)
+@db_handle_error(logger=logger, default_return_val=False)
 def has_sciencewise_ping(paper_id_v: str) -> bool:
     """Determine whether versioned document has a ScienceWISE ping."""
-    try:
-        test: bool = db.session.query(SciencewisePing) \
-            .filter(SciencewisePing.paper_id_v == paper_id_v).count() > 0
-        return test
-    except NoResultFound:
-        return False
-    return False
+    has_ping: bool = db.session.query(SciencewisePing) \
+        .filter(SciencewisePing.paper_id_v == paper_id_v).count() > 0
+    return has_ping
 
 
-@db_handle_operational_error(logger=logger, default_return_val=None)
+@db_handle_error(logger=logger, default_return_val=None)
 def get_dblp_listing_path(paper_id: str) -> Optional[str]:
     """Get the DBLP Bibliography URL for a given document (paper_id)."""
-    try:
-        url: str = db.session.query(DBLP.url).join(Document).filter(
-            Document.paper_id == paper_id).one().url
-        return url
-    except NoResultFound:
-        return None
+    url: str = db.session.query(DBLP.url).join(Document).filter(
+        Document.paper_id == paper_id).one().url
+    return url
 
 
-@db_handle_operational_error(logger=logger, default_return_val=None)
+@db_handle_error(logger=logger, default_return_val=[])
 def get_dblp_authors(paper_id: str) -> List[str]:
     """Get sorted list of DBLP authors for a given document (paper_id)."""
-    try:
-        authors_t = db.session.query(DBLPAuthor.name).\
-            join(DBLPDocumentAuthor).\
-            join(Document).filter(Document.paper_id == paper_id).\
-            order_by(DBLPDocumentAuthor.position).all()
-        authors = [a for (a,) in authors_t]
-        return authors
-    except NoResultFound:
-        return []
+    authors_t = db.session.query(DBLPAuthor.name).\
+        join(DBLPDocumentAuthor).\
+        join(Document).filter(Document.paper_id == paper_id).\
+        order_by(DBLPDocumentAuthor.position).all()
+    authors = [a for (a,) in authors_t]
+    return authors


### PR DESCRIPTION
This is a first stab at handling DB problems in browse more gracefully. I added an error handler as decorator  called `db_handle_operational_error` to the query functions that catches `OperationalError` and `DBAPIError` exceptions from SQLAlchemy and returns a default value; any other exception gets raised and propagated.

I also added a new config `BROWSE_DISABLE_DATABASE` that will cause any function decorated by `db_handle_operational_error` to just return the specified default value; in other words, it short-circuits the connection attempt and query.