### PR TITLE
Add a11y text/link to footer

### DIFF
--- a/browse/templates/base.html
+++ b/browse/templates/base.html
@@ -98,6 +98,7 @@
   <div id="footer">
     <div class="footer-text">
       <p>Link back to: <a href="{{url_for('home')}}">arXiv</a>, <a href="{{url_for('browse.form')}}">form interface</a>, <a href="{{url_for('contact')}}">contact</a>.&nbsp;&nbsp;<span class="help" style="display: inline-block; float: right"><a href="https://confluence.cornell.edu/x/MjmLFQ">Browse v0.1 released 2018-10-22</a>&nbsp;&nbsp;<button class="button is-small" id="feedback-button">Feedback?</button></span></p>
+      <p class="a11y-text" style="margin: 1em 0; padding-top: 1em; border-top: 1px solid #ccc">If you have a disability and are having trouble accessing information on this website or need materials in an alternate format, contact <a href="mailto:web-accessibility@cornell.edu">web-accessibility@cornell.edu</a> for assistance.</p>
     </div>
     <div class="social"><a href="{{url_for('twitter')}}"><img src="//static.arxiv.org/icons/twitter_logo_blue.png" alt="Twitter" title="Follow arXiv on Twitter"/></a></div>
   </div>


### PR DESCRIPTION

![screenshot 2018-11-02 10 47 53](https://user-images.githubusercontent.com/746253/47922170-cfecf200-de8c-11e8-8c90-8e7727e4261b.png)
This is all there is to it for the current browse release; I'll add the homepage footer changes to the ARXIVNG-1296 branch I'm currently working on.